### PR TITLE
np.random.permutation can not handle float

### DIFF
--- a/Create_clients.py
+++ b/Create_clients.py
@@ -23,7 +23,7 @@ def create_clients(num, dir):
     for k in range(num_classes):
         temp = []
         for j in range(num / 100):
-            temp = np.hstack((temp, k * num_examples/10 + np.random.permutation(num_examples/10)))
+            temp = np.hstack((temp, k * num_examples/10 + np.random.permutation(int(num_examples/10))))
         buckets = np.hstack((buckets, temp))
     shards = 2 * num
     perm = np.random.permutation(shards)
@@ -35,7 +35,7 @@ def create_clients(num, dir):
         # perm and stacking two shards together using vstack. Each client now holds 250*2 datapoints.
         z.append(np.hstack((ind_list[int(perm[j])], ind_list[int(perm[j + 1])])))
         # shuffle the data in each element of z, so that each client doesn't have all digits stuck together.
-        perm_2 = np.random.permutation(2 * len(buckets) / shards)
+        perm_2 = np.random.permutation(int(2 * len(buckets) / shards))
         z[-1] = z[-1][perm_2]
     filehandler = open(dir + '/'+str(num)+'_clients.pkl', "wb")
     pickle.dump(z, filehandler)


### PR DESCRIPTION
In Python 3.6.7, numbers being divided are not an integer (it's float number) anymore while np.random.permutation can not handle float number.
Simply add the int() can fix it.